### PR TITLE
Step-0-work updaterisk bug

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,6 +16,7 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
+    this->pendingTrades.clear();
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,14 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerUpdateRisk) {
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
+    riskTracker.addTrade(Trade(6, true, 1.5));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 9, 1e-4);
+    riskTracker.updateRisk();    
+    EXPECT_NEAR(riskTracker.getRisk(), 9, 1e-4);
+}


### PR DESCRIPTION
Found bug where pending trades were not being cleared. Added line in UpdateRisk that clears pending. Was originally unsure what was wrong with behavior. Would consider adding explanation of how risk is calculated to problem description for those unfamiliar. Added testcase to show UpdateRisk does not change if no new trades added (0 pending trades)